### PR TITLE
コンパイル時にコード生成しないように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ $ sbt generator::generate
 [success] Total time: 0 s, completed 2015/06/24 18:17:20
 ```
 
+`sbt compile`時に`generator::generate`を実行したい場合は、build.sbtに以下を追加する。
+
+```scala
+sourceGenerators in Compile <+= generate in generator
+```
+ 
 ## 開発者向け
 
 ### 単体テスト方法

--- a/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorPlugin.scala
+++ b/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorPlugin.scala
@@ -1,6 +1,5 @@
 package jp.co.septeni_original.sbt.dao.generator
 
-import jp.co.septeni_original.sbt.dao.generator.SbtDaoGeneratorKeys._
 import org.seasar.util.lang.StringUtil
 import sbt.Keys._
 import sbt._
@@ -32,8 +31,7 @@ object SbtDaoGeneratorPlugin extends AutoPlugin {
     propertyNameMapper in generator := { columnName: String =>
       StringUtil.decapitalize(StringUtil.camelize(columnName))
     },
-    generate in generator <<= SbtDaoGenerator.generateTask,
-    sourceGenerators in Compile <+= generate in generator
+    generate in generator <<= SbtDaoGenerator.generateTask
   )
 
 }

--- a/src/sbt-test/sbt-dao-generator/simple/build.sbt
+++ b/src/sbt-test/sbt-dao-generator/simple/build.sbt
@@ -27,3 +27,5 @@ typeNameMapper in generator := {
   case "DATE" | "TIMESTAMP" => "java.util.Date"
   case "DECIMAL" => "BigDecimal"
 }
+
+sourceGenerators in Compile <+= generate in generator


### PR DESCRIPTION
コンパイル時にコード生成しないように修正しました。コンパイル時にコード生成を行いたい場合は、手動でbuild.sbtに設定を追加してもらうことになります。
