### PR TITLE
TableDesc や ColumnDesc から型名を算出できる PropertyTypeNameMapper の拡張の導入

### DIFF
--- a/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorKeys.scala
+++ b/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorKeys.scala
@@ -1,5 +1,6 @@
 package jp.co.septeni_original.sbt.dao.generator
 
+import jp.co.septeni_original.sbt.dao.generator.model.{ ColumnDesc, TableDesc }
 import sbt._
 
 /**
@@ -35,6 +36,9 @@ trait SbtDaoGeneratorKeys {
   val typeNameMapper = settingKey[String => String]("type-mapper")
 
   val propertyTypeNameMapper = settingKey[String => String]("property-type-mapper")
+
+  val advancedPropertyTypeNameMapper =
+    settingKey[(String, TableDesc, ColumnDesc) => String]("advanced-property-type-mapper")
 
   val tableNameFilter = settingKey[String => Boolean]("table-name-filter")
 

--- a/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorPlugin.scala
+++ b/src/main/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorPlugin.scala
@@ -1,5 +1,6 @@
 package jp.co.septeni_original.sbt.dao.generator
 
+import jp.co.septeni_original.sbt.dao.generator.model.{ ColumnDesc, TableDesc }
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
@@ -28,7 +29,8 @@ object SbtDaoGeneratorPlugin extends AutoPlugin {
     generator / templateNameMapper := { _: String =>
       "template.ftl"
     },
-    generator / propertyTypeNameMapper := identity,
+    generator / propertyTypeNameMapper := DefaultPropertyTypeNameMapper,
+    generator / advancedPropertyTypeNameMapper := { (s: String, _: TableDesc, _: ColumnDesc) => s },
     generator / tableNameFilter := { _: String =>
       true
     },

--- a/src/main/scala/jp/co/septeni_original/sbt/dao/generator/model/ColumnDesc.scala
+++ b/src/main/scala/jp/co/septeni_original/sbt/dao/generator/model/ColumnDesc.scala
@@ -1,3 +1,9 @@
 package jp.co.septeni_original.sbt.dao.generator.model
 
-case class ColumnDesc(columnName: String, typeName: String, nullable: Boolean, columnSize: Option[Int])
+case class ColumnDesc(
+    columnName: String,
+    typeName: String,
+    nullable: Boolean,
+    columnSize: Option[Int],
+    remarks: Option[String]
+)

--- a/src/sbt-test/sbt-dao-generator/mysql/build.sbt
+++ b/src/sbt-test/sbt-dao-generator/mysql/build.sbt
@@ -1,4 +1,5 @@
 import scala.sys.process.Process
+import jp.co.septeni_original.sbt.dao.generator.model.ColumnDesc
 
 enablePlugins(FlywayPlugin)
 
@@ -33,13 +34,16 @@ generator / jdbcUser := flywayUser.value
 
 generator / jdbcPassword := flywayPassword.value
 
-generator / propertyTypeNameMapper := {
-  case s if s.toUpperCase() == "BIGINT" => "Long"
-  case s if s.toUpperCase() == "INT" => "Int"
-  case s if s.toUpperCase() == "VARCHAR" => "String"
-  case s if s.toUpperCase() == "BOOLEAN" => "Boolean"
-  case s if s.toUpperCase() == "DATE" | s.toUpperCase() == "TIMESTAMP" => "java.util.Date"
-  case s if s.toUpperCase() == "DECIMAL" => "BigDecimal"
+val TypeExtractor = ".*?/TYPE:(.*?)/.*".r
+
+generator / advancedPropertyTypeNameMapper := {
+  case (_, _, ColumnDesc(_, _, _, _, Some(TypeExtractor(t)))) => t.trim
+  case (s, _, _) if s.toUpperCase() == "BIGINT" => "Long"
+  case (s, _, _) if s.toUpperCase() == "INT" => "Int"
+  case (s, _, _) if s.toUpperCase() == "VARCHAR" => "String"
+  case (s, _, _) if s.toUpperCase() == "BOOLEAN" => "Boolean"
+  case (s, _, _) if s.toUpperCase() == "DATE" | s.toUpperCase() == "TIMESTAMP" => "java.util.Date"
+  case (s, _, _) if s.toUpperCase() == "DECIMAL" => "BigDecimal"
 }
 
 generator / classNameMapper := {

--- a/src/sbt-test/sbt-dao-generator/mysql/src/main/resources/db/migration/V1__Create_Tables.sql
+++ b/src/sbt-test/sbt-dao-generator/mysql/src/main/resources/db/migration/V1__Create_Tables.sql
@@ -8,7 +8,7 @@ CREATE TABLE `dept` (
 CREATE TABLE `emp` (
   EMP_ID     INTEGER NOT NULL,
   DEPT_ID    INTEGER NOT NULL,
-  EMP_NAME   VARCHAR(20),
+  EMP_NAME   VARCHAR(20) comment '/TYPE: jp.co.septeni_original.sbt.dao.generator.domain.EmployeeName/',
   HIREDATE   DATE,
   SALARY     NUMERIC(7, 2),
   VERSION_NO INTEGER,

--- a/src/sbt-test/sbt-dao-generator/mysql/src/main/scala/jp/co/septeni_original/sbt/dao/generator/domain/EmployeeName.scala
+++ b/src/sbt-test/sbt-dao-generator/mysql/src/main/scala/jp/co/septeni_original/sbt/dao/generator/domain/EmployeeName.scala
@@ -1,0 +1,3 @@
+package jp.co.septeni_original.sbt.dao.generator.domain
+
+case class EmployeeName(value: String)

--- a/src/test/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorSpec.scala
+++ b/src/test/scala/jp/co/septeni_original/sbt/dao/generator/SbtDaoGeneratorSpec.scala
@@ -29,7 +29,7 @@ create table DEPT (
 create table EMP (
   EMP_ID integer not null primary key,
   DEPT_ID integer not null,
-  EMP_NAME varchar(20),
+  EMP_NAME varchar(20) comment 'employee name',
   HIREDATE date,
   SALARY numeric(7,2),
   VERSION_NO integer,


### PR DESCRIPTION
## 動機

sbt-dao-generator で RDBMSライブラリを利用した Dao の生成をしています。
その際、生成するクラスのプロパティ型を Domain Primitive にしたいケースがあります。

現状の `PropertyTypeNameMapper` では DB のカラム型名から変換するしかなく、テーブル名やカラム名などの情報から型名を算出する事ができません。

例)  employee テーブルの id カラム の型を `EmployeeId` 型にしたい等

## このPRの内容

そこで、カラムの型名だけではなく、 `TableDesc`, `ColumnDesc` も合わせて引数にとる拡張的な PropertyTypeNameMapper を導入しました。

既存の互換性を維持するために、 `propertyTypeNameMapper` SettingKey が設定されていた場合は、そちらを利用する形にしています。

また `ColumnDesc` にコメントを保持する `remarks` フィールドを追加しました。

## その他

`AdvancedPropertyTypeNameMapper` はいい名前が思いつかなかったので仮置きです。いい案あればご指摘ください。

